### PR TITLE
Fix `mdl install-plugin` to be podman compatible

### DIFF
--- a/libexec/mdl-install-plugin.sh
+++ b/libexec/mdl-install-plugin.sh
@@ -148,7 +148,7 @@ for mname in $mnames; do
    done
    # Copy all final work into the container
    while IFS= read -r -d '' dir; do
-      container_tool cp -q "$dir" "$container:$base_dir"
+      container_tool cp "$dir" "$container:$base_dir" 1> /dev/null
    done < <(find "$temp_moodle" -mindepth 1 -maxdepth 1 -type d -print0)
 
    # Clean up


### PR DESCRIPTION
Since Podman does not offer the `podman cp -q` flag, we remove the flag and redirect stdout to /dev/null. This way, any errors will still appear (which is desired), but the command will otherwise be silent.